### PR TITLE
[TECH-322] Update README, support for .NET 7, disable automatic Microsoft.AspNetCore.* dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
 
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: |
+            6.0.x
+            7.0.x
 
       - run: ./Build.ps1
         shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,9 @@ jobs:
 
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: |
+            6.0.x
+            7.0.x
 
       - run: ./Build.ps1
         shell: pwsh

--- a/Build.ps1
+++ b/Build.ps1
@@ -22,7 +22,7 @@ Process {
     
         Exec { & dotnet clean -c Release }
         Exec { & dotnet build -c Release }
-        Exec { & dotnet test  -c Release --no-build -r "$outputDir" --no-restore -l "trx" -l "console;verbosity=detailed" }
+        Exec { & dotnet test  -c Release --no-build --results-directory "$outputDir" --no-restore -l "trx" -l "console;verbosity=detailed" }
         Exec { & dotnet pack  -c Release --no-build -o "$outputDir" }
 
         if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.408",
+    "version": "7.0.203",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }

--- a/renovate.json
+++ b/renovate.json
@@ -19,12 +19,11 @@
   "packageRules": [
     {
       "matchManagers": ["nuget"],
-      "excludePackagePatterns": ["^Microsoft\\.Extensions\\.", "^System\\.", "^dotnet-sdk$"],
       "groupName": "NuGet dependencies"
     },
     {
       "matchManagers": ["nuget"],
-      "matchPackagePatterns": ["^Microsoft\\.Extensions\\.", "^System\\."],
+      "matchPackagePatterns": ["^Microsoft\\.(Extensions|AspNetCore)\\.", "^System\\."],
       "groupName": "Ignored NuGet dependencies",
       "description": "These packages are usually set to a user-defined minimal supported version such as 6.0.0 for .NET 6, and they are overriden by consuming applications",
       "enabled": false

--- a/src/GSoft.AspNetCore.Authentication.ClientCredentialsGrant/GSoft.AspNetCore.Authentication.ClientCredentialsGrant.csproj
+++ b/src/GSoft.AspNetCore.Authentication.ClientCredentialsGrant/GSoft.AspNetCore.Authentication.ClientCredentialsGrant.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -11,7 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" Condition=" '$(TargetFramework)' == 'net7.0' " />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/GSoft.AspNetCore.Authentication.ClientCredentialsGrant/JwtBearerOptionsValidator.cs
+++ b/src/GSoft.AspNetCore.Authentication.ClientCredentialsGrant/JwtBearerOptionsValidator.cs
@@ -12,7 +12,7 @@ internal class JwtBearerOptionsValidator : IValidateOptions<JwtBearerOptions>
         this.AuthScheme = authScheme;
     }
 
-    public ValidateOptionsResult Validate(string name, JwtBearerOptions options)
+    public ValidateOptionsResult Validate(string? name, JwtBearerOptions options)
     {
         var errors = new List<string>();
 

--- a/src/GSoft.Authentication.ClientCredentialsGrant.Tests/AuthenticationBuilderExtensionsTests.cs
+++ b/src/GSoft.Authentication.ClientCredentialsGrant.Tests/AuthenticationBuilderExtensionsTests.cs
@@ -12,7 +12,7 @@ public class AuthenticationBuilderExtensionsTests
     [Fact]
     public void GivenAnAuthenticationBuilder_WhenConfigsArePresent_ThenOptionsAreSet()
     {
-        var inMemorySettings = new Dictionary<string, string>
+        var inMemorySettings = new Dictionary<string, string?>
         {
             [$"Authentication:Schemes:{ClientCredentialsDefaults.AuthenticationScheme}:Authority"] = "https://identity.local",
             [$"Authentication:Schemes:{ClientCredentialsDefaults.AuthenticationScheme}:Audience"] = "audience",
@@ -22,9 +22,7 @@ public class AuthenticationBuilderExtensionsTests
         var configuration = new ConfigurationBuilder().AddInMemoryCollection(inMemorySettings).Build();
         services.AddSingleton<IConfiguration>(configuration);
 
-        var authenticationBuilder = new AuthenticationBuilder(services);
-
-        authenticationBuilder.AddClientCredentials();
+        services.AddAuthentication().AddClientCredentials();
 
         var sp = services.BuildServiceProvider();
 
@@ -41,9 +39,7 @@ public class AuthenticationBuilderExtensionsTests
         var configuration = new ConfigurationBuilder().Build();
         services.AddSingleton<IConfiguration>(configuration);
 
-        var authenticationBuilder = new AuthenticationBuilder(services);
-
-        authenticationBuilder.AddClientCredentials(option =>
+        services.AddAuthentication().AddClientCredentials(option =>
         {
             option.Authority = "https://identity.local";
             option.Audience = "audience";
@@ -61,7 +57,7 @@ public class AuthenticationBuilderExtensionsTests
     public void GivenAnAuthenticationBuilder_WhenUsingCustomSchema_ThenOptionsAreSet()
     {
         var authScheme = "authScheme";
-        var inMemorySettings = new Dictionary<string, string>
+        var inMemorySettings = new Dictionary<string, string?>
         {
             [$"Authentication:Schemes:{authScheme}:Authority"] = "https://identity.local",
             [$"Authentication:Schemes:{authScheme}:Audience"] = "audience",
@@ -71,9 +67,7 @@ public class AuthenticationBuilderExtensionsTests
         var configuration = new ConfigurationBuilder().AddInMemoryCollection(inMemorySettings).Build();
         services.AddSingleton<IConfiguration>(configuration);
 
-        var authenticationBuilder = new AuthenticationBuilder(services);
-
-        authenticationBuilder.AddClientCredentials(authScheme, _ => { });
+        services.AddAuthentication().AddClientCredentials(authScheme, _ => { });
 
         var sp = services.BuildServiceProvider();
 
@@ -87,7 +81,6 @@ public class AuthenticationBuilderExtensionsTests
     public void GivenAnAuthenticationBuilder_WhenOptionsAreConfigured_ThenOptionsAreSet()
     {
         var services = new ServiceCollection();
-        var authenticationBuilder = new AuthenticationBuilder(services);
 
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         services.AddOptions<JwtBearerOptions>(ClientCredentialsDefaults.AuthenticationScheme)
@@ -97,7 +90,7 @@ public class AuthenticationBuilderExtensionsTests
                 options.Authority = "https://identity.local";
             });
 
-        authenticationBuilder.AddClientCredentials();
+        services.AddAuthentication().AddClientCredentials();
 
         var sp = services.BuildServiceProvider();
 
@@ -111,10 +104,9 @@ public class AuthenticationBuilderExtensionsTests
     public void GivenAnAuthenticationBuilder_WhenOptionsAreConfiguredWithAnAction_ThenOptionsAreSet()
     {
         var services = new ServiceCollection();
-        var authenticationBuilder = new AuthenticationBuilder(services);
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
 
-        authenticationBuilder.AddClientCredentials(ClientCredentialsDefaults.AuthenticationScheme, options =>
+        services.AddAuthentication().AddClientCredentials(ClientCredentialsDefaults.AuthenticationScheme, options =>
         {
             options.Audience = "audience";
             options.Authority = "https://identity.local";
@@ -135,8 +127,7 @@ public class AuthenticationBuilderExtensionsTests
         var configuration = new ConfigurationBuilder().Build();
         services.AddSingleton<IConfiguration>(configuration);
 
-        var authenticationBuilder = new AuthenticationBuilder(services);
-        authenticationBuilder.AddClientCredentials();
+        services.AddAuthentication().AddClientCredentials();
 
         var sp = services.BuildServiceProvider();
 

--- a/src/GSoft.Authentication.ClientCredentialsGrant.Tests/ClientCredentialsTokenCacheTests.cs
+++ b/src/GSoft.Authentication.ClientCredentialsGrant.Tests/ClientCredentialsTokenCacheTests.cs
@@ -47,7 +47,7 @@ public class ClientCredentialsTokenCacheTests
 
         await this._tokenCache.SetAsync(TestClientName, token, CancellationToken.None);
 
-        object ignored;
+        object? ignored;
         A.CallTo(() => this._tokenSerializer.Serialize(TestClientName, A<ClientCredentialsToken>._)).MustHaveHappenedOnceExactly()
             .Then(A.CallTo(() => this._memoryCache.CreateEntry(TestCacheKey)).MustHaveHappenedOnceExactly())
             .Then(A.CallTo(() => this._distributedCache.SetAsync(TestCacheKey, A<byte[]>._, A<DistributedCacheEntryOptions>._, CancellationToken.None)).MustHaveHappenedOnceExactly());
@@ -63,7 +63,7 @@ public class ClientCredentialsTokenCacheTests
         var actualToken = await this._tokenCache.GetAsync(TestClientName, CancellationToken.None);
         Assert.Null(actualToken);
 
-        object ignored;
+        object? ignored;
         A.CallTo(() => this._memoryCache.TryGetValue(TestCacheKey, out ignored)).MustHaveHappenedOnceExactly()
             .Then(A.CallTo(() => this._distributedCache.GetAsync(TestCacheKey, CancellationToken.None)).MustHaveHappenedOnceExactly());
 
@@ -83,7 +83,7 @@ public class ClientCredentialsTokenCacheTests
         Assert.Equal(expectedToken, actualToken);
         Assert.NotSame(expectedToken, actualToken);
 
-        object ignored;
+        object? ignored;
         A.CallTo(() => this._memoryCache.TryGetValue(TestCacheKey, out ignored)).MustHaveHappenedOnceExactly()
             .Then(A.CallTo(() => this._tokenSerializer.Deserialize(TestClientName, A<byte[]>._)).MustHaveHappenedOnceExactly());
 
@@ -104,7 +104,7 @@ public class ClientCredentialsTokenCacheTests
         Assert.Equal(expectedToken, actualToken);
         Assert.NotSame(expectedToken, actualToken);
 
-        object ignored;
+        object? ignored;
         A.CallTo(() => this._memoryCache.TryGetValue(TestCacheKey, out ignored)).MustHaveHappenedOnceExactly()
             .Then(A.CallTo(() => this._tokenSerializer.Deserialize(TestClientName, A<byte[]>._)).MustHaveHappenedOnceExactly());
 
@@ -124,7 +124,7 @@ public class ClientCredentialsTokenCacheTests
         Assert.Equal(expectedToken, actualToken);
         Assert.NotSame(expectedToken, actualToken);
 
-        object ignored;
+        object? ignored;
         A.CallTo(() => this._memoryCache.TryGetValue(TestCacheKey, out ignored)).MustHaveHappenedOnceExactly()
             .Then(A.CallTo(() => this._distributedCache.GetAsync(TestCacheKey, CancellationToken.None)).MustHaveHappenedOnceExactly())
             .Then(A.CallTo(() => this._tokenSerializer.Deserialize(TestClientName, A<byte[]>._)).MustHaveHappenedOnceExactly())

--- a/src/GSoft.Authentication.ClientCredentialsGrant.Tests/GSoft.Authentication.ClientCredentialsGrant.Tests.csproj
+++ b/src/GSoft.Authentication.ClientCredentialsGrant.Tests/GSoft.Authentication.ClientCredentialsGrant.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SignAssembly>true</SignAssembly>
@@ -16,8 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Duende.IdentityServer" Version="6.2.3" />
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" Condition=" '$(TargetFramework)' == 'net7.0' " />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/GSoft.Authentication.ClientCredentialsGrant.Tests/JwtBearerOptionsTests.cs
+++ b/src/GSoft.Authentication.ClientCredentialsGrant.Tests/JwtBearerOptionsTests.cs
@@ -54,6 +54,7 @@ public class JwtBearerOptionsTests
     public void Given_Other_JwtBearerOptions_Without_Authority_When_GetOptions_Then_No_Validation()
     {
         var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         services.AddAuthentication().AddJwtBearer("OtherScheme", opt =>
         {
             opt.Authority = "https://authority.io";

--- a/src/GSoft.Authentication.ClientCredentialsGrant.Tests/XunitLoggerProvider.cs
+++ b/src/GSoft.Authentication.ClientCredentialsGrant.Tests/XunitLoggerProvider.cs
@@ -39,6 +39,9 @@ internal sealed class XunitLoggerProvider : ILoggerProvider, ILogger
     }
 
     public IDisposable BeginScope<TState>(TState state)
+#if NET7_0_OR_GREATER
+        where TState : notnull
+#endif
     {
         return new NoopDisposable();
     }

--- a/src/GSoft.Extensions.Http.Authentication.ClientCredentialsGrant/GSoft.Extensions.Http.Authentication.ClientCredentialsGrant.csproj
+++ b/src/GSoft.Extensions.Http.Authentication.ClientCredentialsGrant/GSoft.Extensions.Http.Authentication.ClientCredentialsGrant.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="6.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
* README updated for server-side library
* .NET 7 support added:
  * Because `Microsoft.AspNetCore.Authentication.JwtBearer` isn't part of the default libraries shipped in ASP.NET Core
  * Many changes have been done because of new .NET 7 nullability annotations
  * Now testing on ASP.NET Core 7 too, fixed some tests because service registrations changed
  * Updated CI to install .NET 7 SDK prerequisites
* Disable automatic `Microsoft.AspNetCore.*` dependency updates