### PR TITLE
IDP-404 - Mention metadata address in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ For instance, the example above works well with this `appsettings.json`:
     "Schemes": {
       "ClientCredentials": {
         "Authority": "<oauth2_authorization_server_base_url>",
-        "Audience": "<audience>"
+        "Audience": "<audience>",
+        "MetadataAddress": "<oauth2_authorization_server_metadata_address>"
       }
     }
   }

--- a/src/GSoft.Authentication.ClientCredentialsGrant.Tests/AuthenticationBuilderExtensionsTests.cs
+++ b/src/GSoft.Authentication.ClientCredentialsGrant.Tests/AuthenticationBuilderExtensionsTests.cs
@@ -1,5 +1,4 @@
 ﻿using GSoft.AspNetCore.Authentication.ClientCredentialsGrant;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
It wasn't fully clear people needed to specify the metadata address in the server side config, so I just added it to jour readme example